### PR TITLE
Add request for logo contributions in index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -65,6 +65,7 @@
                             <p>This collection of logos has been built up over the years using both official Microsoft logo packages, as well as hard-to-find places (scraping websites, blog posts, AppSource, product screens, presentations, and anywhere they can be found).</p>
                             <p>It originally lived in OneDrive for use in documents, but then kept being shared with colleagues whenever an incorrect or dated product logo was spotted.</p>
                             <p>As it continued to grow, it was time for it to live on GitHub so the rest of the community can benefit from it, and hopefully contribute!</p>
+                            <p><strong>Want a logo added?</strong> <a href="https://github.com/loryanstrant/MicrosoftCloudLogos/issues/new" target="_blank" rel="noopener noreferrer">Create an issue</a> or <a href="https://github.com/loryanstrant/MicrosoftCloudLogos/pulls" target="_blank" rel="noopener noreferrer">submit a pull request</a>.</p>
                         </div>
                     </div>
                 </div>
@@ -216,7 +217,6 @@
             <div class="intro-card">
                 <h2>Reference Links</h2>
                 <p>These logos are available in the GitHub Pages folder and provide stable URLs that can be embedded in applications like Power BI reports, presentations, or websites. When logos are updated in the repository, these URLs will automatically serve the latest version - no changes needed on your end!</p>
-                <p><strong>Want a logo added?</strong> <a href="https://github.com/loryanstrant/MicrosoftCloudLogos/issues/new" target="_blank" rel="noopener noreferrer">Create an issue</a> or <a href="https://github.com/loryanstrant/MicrosoftCloudLogos/pulls" target="_blank" rel="noopener noreferrer">submit a pull request</a>.</p>
             </div>
             <div class="intro-card">
                 <h2>Available Reference Logos</h2>


### PR DESCRIPTION
This pull request makes a minor update to the `docs/index.html` file, moving the "Want a logo added?" call-to-action from the "Reference Links" section to the "Welcome" section. This change helps new visitors more easily find out how to contribute logos to the collection.